### PR TITLE
The inSender parameter of IOHIDValueCallback (input_callback) is already a HID device.

### DIFF
--- a/JoystickController.m
+++ b/JoystickController.m
@@ -62,7 +62,7 @@ void timer_callback(CFRunLoopTimerRef timer, void *ctx) {
 
 void input_callback(void* inContext, IOReturn inResult, void* inSender, IOHIDValueRef value) {
 	JoystickController* self = (JoystickController*)inContext;
-	IOHIDDeviceRef device = (IOHIDQueueRef) inSender;
+	IOHIDDeviceRef device = (IOHIDDeviceRef) inSender;
 	
 	Joystick* js = [self findJoystickByRef: device];
     ApplicationController *app_controller = [[NSApplication sharedApplication] delegate];


### PR DESCRIPTION
This change fixes the detection of joystick events on Mac OS X 10.6. On 10.9 the old code also worked, presumably because IOHIDQueueGetDevice returned the input parameter as result in case it wasn't an IOHIDQueueRef (on 10.6 it returned NULL)
