### PR TITLE
#7 Fix an issue where mouse movement stops being detected.

### DIFF
--- a/ApplicationController.h
+++ b/ApplicationController.h
@@ -24,6 +24,7 @@
 }
 
 @property(readwrite) BOOL active;
+@property (strong) id activity;
 @property(readonly) JoystickController * jsController;
 @property(readonly) TargetController * targetController;
 @property(readonly) ConfigsController * configsController;

--- a/ApplicationController.m
+++ b/ApplicationController.m
@@ -35,6 +35,12 @@ void onUncaughtException(NSException *exception) {
 	InstallApplicationEventHandler(handler, 1, &et, self, NULL);
 }
 
+-(void) awakeFromNib {
+    if ([[NSProcessInfo processInfo] respondsToSelector:@selector(beginActivityWithOptions:reason:)]) {
+        self.activity = [[NSProcessInfo processInfo] beginActivityWithOptions:0x00FFFFFF reason:@"Let joystick commands fire in the background"];
+    }
+}
+
 -(void) applicationWillTerminate: (NSNotification *)aNotification {
 	[configsController save];
 }


### PR DESCRIPTION
This commit addresses https://github.com/fyhuang/enjoy2/issues/7

On OSX 10.9 and 10.10 app nap causes enjoy to stop recognizing mouse movement input after a brief period of time. This uses beginActivityWithOptions to prevent the app from idling and being unable to control the cursor.

Reference: https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSProcessInfo_Class/index.html#//apple_ref/occ/instm/NSProcessInfo/beginActivityWithOptions:reason:
