### PR TITLE
Fixed trigger for config change

### DIFF
--- a/TargetConfig.m
+++ b/TargetConfig.m
@@ -29,7 +29,7 @@
 	return NULL;
 }
 
--(void) trigger {
+-(void) trigger (JoystickController *)jc {
 	[[[[NSApplication sharedApplication] delegate] configsController] activateConfig:config forApplication: NULL];
 }
 


### PR DESCRIPTION
Target.h declares that the trigger method must have a parameter.  The trigger method in TargetConfig.m does not.  Added parameter (even though it doesn't use it, similar to other Target*.m).  Config can now be changed as a trigger.
