### PR TITLE
Fix broken joystick event detection

### DIFF
--- a/Joystick.h
+++ b/Joystick.h
@@ -7,11 +7,13 @@
 //
 
 #import <Cocoa/Cocoa.h>
+@class JoystickController;
 @class JSAction;
 
 @interface Joystick : NSObject {
 	int vendorId;
 	int productId;
+    JoystickController *controller;
 	int index;
 	NSString* productName;
 	IOHIDDeviceRef device;
@@ -21,6 +23,7 @@
 
 @property(readwrite) int vendorId;
 @property(readwrite) int productId;
+@property(readwrite, copy) JoystickController* controller;
 @property(readwrite) int index;
 @property(readwrite, copy) NSString* productName;
 @property(readwrite) IOHIDDeviceRef device;
@@ -30,7 +33,7 @@
 -(void) populateActions;
 -(void) invalidate;
 -(id) handlerForEvent: (IOHIDValueRef) value;
--(id)initWithDevice: (IOHIDDeviceRef) newDevice;
+-(id)initWithDevice: (IOHIDDeviceRef) newDevice andController: (JoystickController*) controller;
 -(JSAction*) actionForEvent: (IOHIDValueRef) value;
 
 @end

--- a/Joystick.h
+++ b/Joystick.h
@@ -13,7 +13,7 @@
 @interface Joystick : NSObject {
 	int vendorId;
 	int productId;
-    JoystickController *controller;
+	JoystickController *controller;
 	int index;
 	NSString* productName;
 	IOHIDDeviceRef device;

--- a/Joystick.m
+++ b/Joystick.m
@@ -15,7 +15,7 @@
 		children = [[NSMutableArray alloc]init];
 		
 		device = newDevice;
-        controller = newController;
+		controller = newController;
 		productName = (NSString*)IOHIDDeviceGetProperty( device, CFSTR(kIOHIDProductKey) );
 		vendorId = [(NSNumber*)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDVendorIDKey)) intValue];
 		productId = [(NSNumber*)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDVendorIDKey)) intValue];

--- a/Joystick.m
+++ b/Joystick.m
@@ -8,13 +8,14 @@
 @implementation Joystick
 
 
-@synthesize	vendorId, productId, productName, name, index, device, children;
+@synthesize	vendorId, productId, productName, name, controller, index, device, children;
 
--(id)initWithDevice: (IOHIDDeviceRef) newDevice {
+-(id)initWithDevice: (IOHIDDeviceRef) newDevice andController: (JoystickController*) newController {
 	if(self=[super init]) {
 		children = [[NSMutableArray alloc]init];
 		
 		device = newDevice;
+        controller = newController;
 		productName = (NSString*)IOHIDDeviceGetProperty( device, CFSTR(kIOHIDProductKey) );
 		vendorId = [(NSNumber*)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDVendorIDKey)) intValue];
 		productId = [(NSNumber*)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDVendorIDKey)) intValue];

--- a/JoystickController.m
+++ b/JoystickController.m
@@ -61,10 +61,10 @@ void timer_callback(CFRunLoopTimerRef timer, void *ctx) {
 }
 
 void input_callback(void* inContext, IOReturn inResult, void* inSender, IOHIDValueRef value) {
-	JoystickController* self = (JoystickController*)inContext;
+    Joystick *js = (Joystick *) inContext;
+	JoystickController* self = [js controller];
 	IOHIDDeviceRef device = (IOHIDDeviceRef) inSender;
-	
-	Joystick* js = [self findJoystickByRef: device];
+
     ApplicationController *app_controller = [[NSApplication sharedApplication] delegate];
 	if([app_controller active]) {
 		// for reals
@@ -137,15 +137,16 @@ void add_callback(void* inContext, IOReturn inResult, void* inSender, IOHIDDevic
 	JoystickController* self = (JoystickController*)inContext;
 	
 	IOHIDDeviceOpen(device, kIOHIDOptionsTypeNone);
-	IOHIDDeviceRegisterInputValueCallback(device, input_callback, (void*) self);
 	
-	Joystick *js = [[Joystick alloc] initWithDevice: device];
+	Joystick *js = [[Joystick alloc] initWithDevice: device andController: self];
 	[js setIndex: findAvailableIndex([self joysticks], js)];
 	
 	[js populateActions];
 
 	[[self joysticks] addObject: js];
 	[self->outlineView reloadData];
+
+	IOHIDDeviceRegisterInputValueCallback(device, input_callback, (void*) js);
 }
 	
 -(Joystick*) findJoystickByRef: (IOHIDDeviceRef) device {

--- a/JoystickController.m
+++ b/JoystickController.m
@@ -61,11 +61,11 @@ void timer_callback(CFRunLoopTimerRef timer, void *ctx) {
 }
 
 void input_callback(void* inContext, IOReturn inResult, void* inSender, IOHIDValueRef value) {
-    Joystick *js = (Joystick *) inContext;
+	Joystick *js = (Joystick *) inContext;
 	JoystickController* self = [js controller];
 	IOHIDDeviceRef device = (IOHIDDeviceRef) inSender;
 
-    ApplicationController *app_controller = [[NSApplication sharedApplication] delegate];
+	ApplicationController *app_controller = [[NSApplication sharedApplication] delegate];
 	if([app_controller active]) {
 		// for reals
 		JSAction* mainAction = [js actionForEvent: value];


### PR DESCRIPTION
I am using Mac OS X version 10.8.2 with an XBOX 360 Controller via the tattiebogle driver.

I found that no events appeared to be detected by the Enjoy2 UI.

I diagnosed the problem as the "inSender" parameter of the input_callback not being passed as the device.  It appears to be a value unrelated to the actual joystick device.

It would seem safer to simply store the controller pointer in the joystick and make the joystick be the callback data.  Then you don't have to try to look the joystick up by device id.

I made this change and Enjoy2 started working for my controller.

I am not an Objective-C programmer and I had to figure out the syntax of and correct approach for the code change as I went.  My apologies if the style is bad or the change is in some way deficient.
